### PR TITLE
Create filter for savoltoyota product name pós venda

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    savolvw (0.1.7)
+    savolvw (0.1.8)
 
 GEM
   remote: https://rubygems.org/
@@ -58,4 +58,4 @@ DEPENDENCIES
   savolvw!
 
 BUNDLED WITH
-   2.2.19
+   2.3.10

--- a/lib/savolvw.rb
+++ b/lib/savolvw.rb
@@ -74,6 +74,8 @@ module Savolvw
         "#{source_name} - PCD"
       elsif product_name_downcase.include?('frotista')
         "#{source_name} - Frotista"
+      elsif product_name_downcase.include?('pós-venda')
+        "#{source_name} - Pós Vendas"
       else
         lead.source.name
       end

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -42,5 +42,31 @@ RSpec.describe F1SalesCustom::Hooks::Lead do
         expect(described_class.switch_source(lead)).to eq('Facebook - Savol Volkswagen - Frotista')
       end
     end
+
+    context 'when product contains Pós-venda' do
+      let(:product) do
+        product = OpenStruct.new
+        product.name = 'Pós-venda: Pneu - Maio22 (Instagram)'
+
+        product
+      end
+
+      it 'returns source name' do
+        expect(described_class.switch_source(lead)).to eq('Facebook - Savol Volkswagen - Pós Vendas')
+      end
+    end
+
+    context 'when product is common' do
+      let(:product) do
+        product = OpenStruct.new
+        product.name = 'Pneu - Maio22 (Instagram)'
+
+        product
+      end
+
+      it 'returns source name' do
+        expect(described_class.switch_source(lead)).to eq('Facebook - Savol Volkswagen')
+      end
+    end
   end
 end


### PR DESCRIPTION
Create a filter for Savol Toyota and Savol Toyota Praia Grande. They want to separate the Pós Venda product for a simgle salesman.